### PR TITLE
Add snmalloc as a sanitizer option

### DIFF
--- a/sanitizer_configs/snmalloc.xml
+++ b/sanitizer_configs/snmalloc.xml
@@ -1,0 +1,18 @@
+<sanitizer>
+    <name>snmalloc-checked</name>
+    <setup_baseline>
+        <compile_cmd>clang -Wl,-T,../sanitizers/after_text.ld $SOURCE_FILE -o $GENERATED_BINARY</compile_cmd>
+    </setup_baseline>
+    <run_baseline>$GENERATED_BINARY</run_baseline>
+    <setup>
+        <compile_cmd>clang -Wl,-T,../sanitizers/after_text.ld $SOURCE_FILE -o $GENERATED_BINARY</compile_cmd>
+    </setup>
+    <run_env_args>
+        <env_var name="LD_PRELOAD">../sanitizers/snmalloc/build/libsnmallocshim-checks.so</env_var>
+    </run_env_args>
+    <run>$GENERATED_BINARY</run>
+    <bug_detected_exit_values>
+        <value>1</value>
+        <value>6</value>
+    </bug_detected_exit_values>
+</sanitizer>

--- a/sanitizer_configs/snmalloc.xml
+++ b/sanitizer_configs/snmalloc.xml
@@ -14,5 +14,7 @@
     <bug_detected_exit_values>
         <value>1</value>
         <value>6</value>
+        <value>4</value>
+        <value>132</value>
     </bug_detected_exit_values>
 </sanitizer>


### PR DESCRIPTION
This commit adds snmalloc as an option for the sanitizer. It requires the snmalloc code to be checked out and built. The following sequence of commands starting in the root of the checkout should work.
```
cd sanitizers
git clone https://github.com/microsoft/snmalloc
mkdir snmalloc/build
cd snmalloc/build
cmake ..
make snmallocshim-checks
```

Some of the checks in snmalloc are probablistic, so multiple runs should be performed to get an accurate representation of its detection rate.